### PR TITLE
Updated published image tags to consume gh wf matrix dockerfile

### DIFF
--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -32,5 +32,5 @@ jobs:
         with:
           context: ${{ matrix.DOCKERFILE_DIR }}
           push: true
-          tags: ${{ steps.metadata.outputs.tags }}
+          tags: ghcr.io/${{ github.repository }}/${{ matrix.DOCKERFILE_DIR }}:${{ github.ref }}
           labels: ${{ steps.metadata.outputs.labels }}


### PR DESCRIPTION
Goal is to differentiate between client/server, previously both were being overridden.